### PR TITLE
feat: Implement PricingPage with auth and mock checkout endpoint

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import MinhasPlaylists from "@/pages/MinhasPlaylists";
 import PlaylistCompartilhada from "@/pages/PlaylistCompartilhada";
 import ConfigSpotify from "@/pages/ConfigSpotify";
 import ConfiguracaoIA from "@/pages/ConfiguracaoIA";
+import PricingPage from "@/pages/PricingPage"; // Import the PricingPage component
 import NotFound from "@/pages/not-found";
 
 function Router() {
@@ -25,6 +26,7 @@ function Router() {
           <Route path="/playlists" component={MinhasPlaylists} />
           <Route path="/config-spotify" component={ConfigSpotify} />
           <Route path="/config-ia" component={ConfiguracaoIA} />
+          <Route path="/pricing" component={PricingPage} /> {/* Add pricing route */}
         </>
       )}
       <Route path="/shared/:token" component={PlaylistCompartilhada} />

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -6,9 +6,17 @@ export function useAuth() {
     retry: false,
   });
 
+  // The Replit authentication mechanism uses httpOnly cookies.
+  // The token is not (and should not be) accessible to client-side JavaScript.
+  // `fetch` calls with `credentials: "include"` (as used in `apiRequest`)
+  // will automatically send the session cookie to the backend for authentication.
+  // Thus, no explicit token handling is needed here or in API calling components
+  // for the purpose of an Authorization header.
+
   return {
     user,
     isLoading,
     isAuthenticated: !!user,
+    // No token is exposed here as it's not available/needed for manual header setting.
   };
 }

--- a/client/src/pages/PricingPage.tsx
+++ b/client/src/pages/PricingPage.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/hooks/useAuth';
+import { useToast } from "@/hooks/use-toast"; // Corrected import path
+import { apiRequest } from '@/lib/queryClient'; // Import apiRequest
+
+const PricingPage: React.FC = () => {
+  const { isAuthenticated, isLoading } = useAuth(); // Get isAuthenticated status
+  const { toast } = useToast();
+
+  const handleCheckout = async (planId: string) => {
+    if (isLoading) {
+      toast({ title: "Aguarde", description: "Verificando autenticação..." });
+      return;
+    }
+
+    if (!isAuthenticated) {
+      toast({
+        title: "Erro de Autenticação",
+        description: "Você precisa estar logado para realizar um checkout.",
+        variant: "destructive",
+      });
+      console.error('User not authenticated.');
+      return;
+    }
+
+    console.log('Checkout initiated for plan:', planId);
+
+    try {
+      // Use apiRequest for the call, which handles credentials correctly
+      const response = await apiRequest(
+        'POST',
+        '/api/stripe/create-checkout-session',
+        { planId }
+      );
+
+      // apiRequest throws for non-ok responses, so no need to check response.ok here.
+      const session = await response.json();
+      console.log('Checkout session created:', session);
+      toast({
+        title: "Checkout Iniciado",
+        description: "Redirecionando para o Stripe...",
+      });
+      // TODO: Redirect to Stripe checkout page using session.url or session.id
+      // For example: window.location.href = session.url;
+      // Or using Stripe.js: stripe.redirectToCheckout({ sessionId: session.id });
+    } catch (error) {
+      console.error('Checkout error:', error);
+      toast({
+        title: "Erro no Checkout",
+        description: error instanceof Error ? error.message : "Ocorreu um erro desconhecido.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <div className="container mx-auto py-12">
+      <h1 className="text-4xl font-bold text-center mb-12">Planos e Preços</h1>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        {/* Example Plan */}
+        <div className="border p-6 rounded-lg shadow-lg">
+          <h2 className="text-2xl font-semibold mb-4">Plano Básico</h2>
+          <p className="text-3xl font-bold mb-6">R$ 9,90<span className="text-sm font-normal">/mês</span></p>
+          <ul className="mb-6 space-y-2">
+            <li>Recurso 1</li>
+            <li>Recurso 2</li>
+            <li>Recurso 3</li>
+          </ul>
+          <Button onClick={() => handleCheckout('basic_plan_id')} className="w-full">
+            Selecionar Plano
+          </Button>
+        </div>
+
+        {/* Add more plans here */}
+      </div>
+    </div>
+  );
+};
+
+export default PricingPage;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -236,6 +236,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const { planId } = req.body;
         const userId = req.user.claims.sub;
 
+        // Validate planId
+        const validPlans = ["basic", "premium", "pro"]; // Example valid plans
+        if (!planId || !validPlans.includes(planId)) {
+          return res.status(400).json({
+            message: "Invalid or missing planId. Please provide a valid plan.",
+          });
+        }
         console.log(
           `User ${userId} is attempting to create a checkout session for plan ${planId}.`
         );

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -230,7 +230,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post(
     "/api/stripe/create-checkout-session",
     isAuthenticated,
-    async (req: any, res) => {
+    async (req: Request<{}, {}, { planId: string }, {}> & { user: { claims: { sub: string } } }, res: Response) => {
       try {
         // TODO: Implement actual Stripe session creation logic
         const { planId } = req.body;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -225,6 +225,39 @@ export async function registerRoutes(app: Express): Promise<Server> {
             .json({
               message: "Não foi possível gerar faixas para este prompt",
             });
+
+  // Stripe routes
+  app.post(
+    "/api/stripe/create-checkout-session",
+    isAuthenticated,
+    async (req: any, res) => {
+      try {
+        // TODO: Implement actual Stripe session creation logic
+        const { planId } = req.body;
+        const userId = req.user.claims.sub;
+
+        console.log(
+          `User ${userId} is attempting to create a checkout session for plan ${planId}.`
+        );
+
+        // Mock response for now
+        res.json({
+          message: "Stripe checkout session created successfully (mock).",
+          sessionId: `mock_session_${Date.now()}`,
+          planId: planId,
+          userId: userId,
+        });
+      } catch (error) {
+        console.error("Erro ao criar sessão de checkout Stripe:", error);
+        res
+          .status(500)
+          .json({ message: "Erro ao criar sessão de checkout Stripe." });
+      }
+    }
+  );
+
+  const httpServer = createServer(app);
+  return httpServer;
         }
 
         // Create playlist on Spotify


### PR DESCRIPTION
- Create PricingPage.tsx with basic layout.
- Implement authentication for handleCheckout using httpOnly cookie (via apiRequest).
- Add /pricing route for authenticated users in App.tsx.
- Add mock /api/stripe/create-checkout-session backend endpoint.
- Correct useToast import path in PricingPage.tsx.