### PR TITLE
Potential fix for code scanning alert no. 27: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "express-rate-limit": "^7.5.1"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,4 +1,5 @@
 import type { Express } from "express";
+import rateLimit from "express-rate-limit";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { setupAuth, isAuthenticated } from "./replitAuth";
@@ -536,7 +537,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Get rate limit status (simplified for now)
-  app.get("/api/user/rate-limit", isAuthenticated, async (req: any, res) => {
+  const rateLimit = require("express-rate-limit");
+  const rateLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 1 hour
+    max: 10, // Limit each IP to 10 requests per hour
+    message: { message: "Too many requests, please try again later." },
+  });
+
+  app.get("/api/user/rate-limit", isAuthenticated, rateLimiter, async (req: any, res) => {
     try {
       res.json({
         remainingRequests: 10, // Fixed for now

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -517,7 +517,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Update user AI settings
-  app.put("/api/user/ai-settings", isAuthenticated, async (req: any, res) => {
+  const aiSettingsRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 50, // Limit each IP to 50 requests per windowMs
+    message: { message: "Too many requests, please try again later." },
+  });
+
+  app.put("/api/user/ai-settings", isAuthenticated, aiSettingsRateLimiter, async (req: any, res) => {
     try {
       const userId = req.user.claims.sub;
       const { aiProvider, apiKeys } = req.body;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -544,9 +544,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Get rate limit status (simplified for now)
   const rateLimit = require("express-rate-limit");
+  const RATE_LIMIT_WINDOW_MS = process.env.RATE_LIMIT_WINDOW_MS ? parseInt(process.env.RATE_LIMIT_WINDOW_MS, 10) : 60 * 60 * 1000; // 1 hour
+  const RATE_LIMIT_MAX = process.env.RATE_LIMIT_MAX ? parseInt(process.env.RATE_LIMIT_MAX, 10) : 10; // Limit each IP to 10 requests per hour
+
   const rateLimiter = rateLimit({
-    windowMs: 60 * 60 * 1000, // 1 hour
-    max: 10, // Limit each IP to 10 requests per hour
+    windowMs: RATE_LIMIT_WINDOW_MS,
+    max: RATE_LIMIT_MAX,
     message: { message: "Too many requests, please try again later." },
   });
 


### PR DESCRIPTION
Potential fix for [https://github.com/leonardobora/GeraAI/security/code-scanning/27](https://github.com/leonardobora/GeraAI/security/code-scanning/27)

To address the issue, we will add rate limiting to the `/api/user/rate-limit` endpoint using the `express-rate-limit` package. This middleware will restrict the number of requests a user can make to the endpoint within a specified time window. The rate limiter will be configured to allow a reasonable number of requests per hour, ensuring that legitimate users can access the endpoint without disruption while preventing abuse.

**Steps to implement the fix:**
1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Create a rate limiter instance with appropriate configuration (e.g., 10 requests per hour).
4. Apply the rate limiter middleware specifically to the `/api/user/rate-limit` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
